### PR TITLE
Shift Conda channels from Dockerfile to environment.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM continuumio/miniconda
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
         build-essential
 
-RUN conda config --add channels bioconda \
-    && conda config --add channels conda-forge
-
 WORKDIR /opt/biophi
 
 COPY environment.yml .

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 channels:
-  - defaults
+  - nodefaults
   - bioconda
-  - anaconda
   - conda-forge
 dependencies:
   - python = 3.8

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,8 @@
----
+channels:
+  - defaults
+  - bioconda
+  - anaconda
+  - conda-forge
 dependencies:
   - python = 3.8
   - pip


### PR DESCRIPTION
This PR shifts Conda channels from `Dockerfile` to `environment.yml`.

This enables building the Conda environment outside of Docker.