### PR TITLE
Fix np.int error

### DIFF
--- a/biophi/humanization/methods/humanness.py
+++ b/biophi/humanization/methods/humanness.py
@@ -80,7 +80,7 @@ class ChainHumanness:
         if frequency:
             curve = curve / curve.sum()
         else:
-            curve = curve.astype(np.int)
+            curve = curve.astype(int)
 
         if cumulative:
             curve = curve[::-1].cumsum()[::-1]


### PR DESCRIPTION
Fixing np.int bug. https://github.com/Merck/BioPhi/issues/42

Numpy no longer aliases `np.int`. Instead it recommends just to use the built in `int` type.