### PR TITLE
Foun 1338 enable multiple humanization variants in biophi

### DIFF
--- a/biophi/humanization/cli/sapiens.py
+++ b/biophi/humanization/cli/sapiens.py
@@ -3,6 +3,7 @@ from multiprocessing import Pool
 import os
 from pathlib import Path
 import sys
+from typing import List, Optional
 
 from abnumber import Chain, ChainParseError, SUPPORTED_CDR_DEFINITIONS, SUPPORTED_SCHEMES
 from Bio import SeqIO
@@ -235,7 +236,28 @@ def sapiens_fasta_only(inputs, output_fasta, humanization_params, limit=None):
         click.echo('Done.', err=True)
 
 
-def sapiens_generate_only(inputs, output_fasta, humanization_params, limit=None, initial_n_samples=1000) -> None:
+def sapiens_generate_only(
+    inputs: List[str],
+    output_fasta: str,
+    humanization_params: HumanizationParams,
+    limit: Optional[int]=None,
+    initial_n_samples: int=1000
+) -> None:
+    """Generates initial_n_samples sequences using the output of the sapiens model.
+    
+    The model outputs a probability matrix where for each residue of the input sequence
+    we are given the probabilities of an amino acid being in that position.
+    We use this matrix as a sampling distribution to generate new sequences. We try to generate
+    initial_n_samples sequences, and drop any duplicates that are generated.
+
+    Args:
+        inputs: List of fasta files with sequences to humanize.
+        output_fasta: Fasta file to write the generated sequences to.
+        humanization_params: The params used to humanize the input sequences.
+        limit: Number of input sequences to process from inputs. Defaults to None.
+        initial_n_samples: target number of samples to generate. Defaults to 1000.
+
+    """
     if output_fasta:
         output_dir = Path(output_fasta)
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/biophi/humanization/cli/sapiens.py
+++ b/biophi/humanization/cli/sapiens.py
@@ -38,7 +38,8 @@ from tqdm import tqdm
 @click.option('--cdr-definition', default=HumanizationParams.cdr_definition, help=f'CDR definition: one of {", ".join(SUPPORTED_CDR_DEFINITIONS)}')
 @click.option('--humanize-cdrs', is_flag=True, default=False, type=bool, help='Allow humanizing mutations in CDRs')
 @click.option('--limit', required=False, metavar='N', type=int, help='Process only first N records')
-def sapiens(inputs, output, fasta_only, scores_only, mean_score_only, generate_only, version, iterations, scheme, cdr_definition, humanize_cdrs, limit, oasis_db):
+@click.option('--n_generated_sequences', required=False, type=int, default=1000, help='Number of sequences to output when using --generate-only')
+def sapiens(inputs, output, fasta_only, scores_only, mean_score_only, generate_only, version, iterations, scheme, cdr_definition, humanize_cdrs, limit, oasis_db, n_generated_sequences):
     """Sapiens: Antibody humanization using deep learning.
 
      Sapiens is trained on 20 million natural antibody sequences
@@ -128,7 +129,7 @@ def sapiens(inputs, output, fasta_only, scores_only, mean_score_only, generate_o
                 output,
                 limit=limit,
                 humanization_params=humanization_params,
-
+                initial_n_samples=n_generated_sequences,
             )
         else:
             from biophi.common.web.views import app


### PR DESCRIPTION
A fix for #47. @prihoda 

Currently, the output of the humanization step returns a single fasta file. I would be interested in having the output have multiple sequences that are based on sampling from the output from the model.
I have a POC to do this in the cli, we could discuss what this would look like in the web client if needed.